### PR TITLE
Remove "AS" in prepareTable for Oracle dialect

### DIFF
--- a/phalcon/db/dialect/oracle.zep
+++ b/phalcon/db/dialect/oracle.zep
@@ -391,11 +391,25 @@ class Oracle extends Dialect
 	 */
 	protected function prepareTable(string! table, string schema = null, string alias = null, string escapeChar = null) -> string
 	{
-		return parent::prepareTable(
-			Text::upper(table),
-			Text::upper(schema),
-			alias,
-			escapeChar
-		);
+		let table = Text::upper(table);
+		let schema = Text::upper(schema);
+	
+		let table = this->escape(table, escapeChar);
+
+		/**
+		 * Schema
+		 */
+		if schema != "" {
+			let table = this->escapeSchema(schema, escapeChar) . "." . table;
+		}
+
+		/**
+		 * Alias
+		 */
+		if alias != "" {
+			let table = table . " " . this->escape(alias, escapeChar);
+		}
+
+		return table;
 	}
 }


### PR DESCRIPTION
In oracle dialect it is TABLE alias, without the AS. 
AS is only used for variable aliasing. 
I don't think it is possible without copying code from parent, because you need to remove the "AS" part.